### PR TITLE
ci: apply zizmor security fixes to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install
       - run: bun run lint
@@ -19,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install
       - run: bun run build
@@ -27,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install
       - run: bun test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
+          no-cache: true
 
       - name: Install dependencies
         run: bun install
@@ -57,6 +60,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
## Changes

- Add `persist-credentials: false` to every `actions/checkout` step.
- **[Needs review] `release.yml`: cache-poisoning fix adds `no-cache: true` to `oven-sh/setup-bun`, which disables caching for the release build.**

Applies the auto-fixes from zizmor 1.25.2 using `--fix=all`.

## Background

`--fix=safe` applies nothing here: the `artipacked` (persist-credentials) auto-fix is classified as unsafe, so every fix is held back in safe mode. `--fix=all` is used instead.

## Notes

- SHA pinning is out of scope — it is delegated to Renovate (`config:best-practices`).
- `excessive-permissions` findings have no auto-fix and are handled separately, per job.
- None of the affected workflows run `git push`; they all pass `secrets.GITHUB_TOKEN` explicitly, so `persist-credentials: false` is not expected to break anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
