### PR TITLE
ci: allow manual dispatch of the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch: {}
   push:
     tags:
       - "v*"
@@ -53,6 +54,7 @@ jobs:
 
   release:
     needs: build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Changes

- Add `workflow_dispatch` to the Release workflow.
- Gate the `release` job on `startsWith(github.ref, 'refs/tags/')`.

## Why

The `build` job currently has no way to be exercised outside a tag push, which makes changes to it impossible to verify before release. Adding `workflow_dispatch` fixes that.

The guard on the `release` job is required for that to be safe. `softprops/action-gh-release` is used without a `tag_name` input, so it derives the tag from `github.ref`. Dispatching on a branch would therefore either fail or publish a release named after the branch. Gating the job on a tag ref means a manual dispatch runs `build` only and skips releasing entirely, while tag pushes keep working exactly as before.

## Follow-up

This unblocks verification of #52, which changes the `build` job (adds `no-cache: true` to `oven-sh/setup-bun` as a cache-poisoning fix) and currently cannot be tested without cutting a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
