### PR TITLE
ci: scope release permissions and add default shell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,11 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   build:
@@ -58,6 +62,8 @@ jobs:
   release:
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Changes

- Narrow the top-level `permissions` to `contents: read`.
- Move `contents: write` to the `release` job, which is the only job that creates a release.
- Add `defaults.run.shell: bash`.

## Why

The `build` matrix jobs only check out the repository and upload artifacts, but they were running with `contents: write`. This is the same scoping applied to the other workflows in this account.

This was the last file still carrying a zizmor `excessive-permissions` finding across all repos in this account. With this change `zizmor --offline` reports no findings above Informational for this repository.

Verified with `actionlint` (no new findings) and a zizmor re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
