### PR TITLE
ci: use gh release instead of a third-party action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,10 +79,13 @@ jobs:
           path: artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          files: |
-            artifacts/nooon-linux-x64/nooon-linux-x64
-            artifacts/nooon-linux-arm64/nooon-linux-arm64
-            artifacts/nooon-darwin-x64/nooon-darwin-x64
-            artifacts/nooon-darwin-arm64/nooon-darwin-arm64
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          gh release create "${GITHUB_REF_NAME}"
+          artifacts/nooon-linux-x64/nooon-linux-x64
+          artifacts/nooon-linux-arm64/nooon-linux-arm64
+          artifacts/nooon-darwin-x64/nooon-darwin-x64
+          artifacts/nooon-darwin-arm64/nooon-darwin-arm64
+          --verify-tag
+          --notes ""


### PR DESCRIPTION
## Changes

- Replace `softprops/action-gh-release` with `gh release create` in the `release` job.

## Why

zizmor's [`superfluous-actions`](https://docs.zizmor.sh/audits/#superfluous-actions) audit flags this: `gh` is preinstalled on GitHub-hosted runners, so a third-party action is not needed to cut a release. Dropping it removes one dependency from the release path, which is exactly where supply-chain surface matters most.

## Safety

`softprops/action-gh-release` had a useful property this replaces: with no `tag_name` and a non-tag ref it [throws before touching the API](https://github.com/softprops/action-gh-release/blob/3d0d9888cb7fd7b750713d6e236d1fcb99157228/src/run.ts), which meant a mistaken dispatch failed instead of publishing something.

`gh release create` has the opposite default — if the tag does not exist it [creates one from the latest state of the default branch](https://cli.github.com/manual/gh_release_create) and publishes a real release. So `--verify-tag` is not optional here; it aborts when the tag is not already on the remote, restoring the same protection. The existing `if: startsWith(github.ref, 'refs/tags/')` guard stays as the first layer.

## Behavior

`GITHUB_REF_NAME` is the tag name, matching what the action derived from `github.ref`. `--notes ""` reproduces the empty body the action produced (`generate_release_notes` defaulted to false). `draft` and `prerelease` default to false in `gh`, same as before.

## Verification

`actionlint` and `zizmor --offline` both clean. Note this workflow only runs on tag pushes, so it is **not** covered by pull request CI — the first real exercise will be the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
