### PR TITLE
fix: make the release step idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,11 +81,15 @@ jobs:
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          gh release create "${GITHUB_REF_NAME}"
-          artifacts/nooon-linux-x64/nooon-linux-x64
-          artifacts/nooon-linux-arm64/nooon-linux-arm64
-          artifacts/nooon-darwin-x64/nooon-darwin-x64
-          artifacts/nooon-darwin-arm64/nooon-darwin-arm64
-          --verify-tag
-          --notes ""
+        run: |
+          assets=(
+            artifacts/nooon-linux-x64/nooon-linux-x64
+            artifacts/nooon-linux-arm64/nooon-linux-arm64
+            artifacts/nooon-darwin-x64/nooon-darwin-x64
+            artifacts/nooon-darwin-arm64/nooon-darwin-arm64
+          )
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" "${assets[@]}" --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" "${assets[@]}" --verify-tag --notes ""
+          fi


### PR DESCRIPTION
## Changes

- Make the release step idempotent: upload to the existing release instead of failing when one is already present.

## Why

`softprops/action-gh-release`, which this workflow used until earlier today, updates an existing release rather than failing: *"If a tag already has a GitHub release, the existing release will be updated with the release assets"* ([README](https://github.com/softprops/action-gh-release/blob/3d0d9888cb7fd7b750713d6e236d1fcb99157228/README.md)). `gh release create` fails instead — observed for real in [this run](https://github.com/corrupt952/SnackTime/actions/runs/32208348696): `a release with the same tag name already exists`.

Replacing the action therefore removed the ability to re-run a release after a partial failure. If an asset upload dies on a network error, the old setup recovered on re-run; the new one failed until the release was deleted by hand. All three release workflows have `workflow_dispatch`, so re-running is a real path, not a hypothetical.

Checking for an existing release and falling back to `gh release upload --clobber` restores that. The `--verify-tag` guard stays on the create path.

This is a regression I introduced today and did not flag in the PR that made the switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
