### PR TITLE
fix: stop skipping status checks for Renovate automerge

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,9 +2,6 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: [
     'github>corrupt952/renovate-config:default.json5',
-
-    // CAUTION: This repository has no tests, so skip status checks
-    ':skipStatusChecks',
   ],
 
   assignees: ['@corrupt952'],


### PR DESCRIPTION
## Changes

- Drop `:skipStatusChecks`.

## Why

The comment next to it said *"This repository has no tests, so skip status checks"*. That has not been true for a while — this repository has CI, and a zizmor job was added today on top of it.

`:skipStatusChecks` sets `ignoreTests: true`, so Renovate automerges without waiting for any check to finish. Combined with `automerge: true` for minor/patch/pin/digest updates in the shared config, dependency updates were landing on the default branch with CI results ignored entirely.

Removing it makes automerge wait for checks, which is the intended behavior of the shared config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
