### PR TITLE
ci: add concurrency groups to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
     tags:
       - "v*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Changes

- Add `concurrency` to the workflows that lacked it.

## Why

Without a `concurrency` group, pushing to a PR leaves the previous run going, so several runs of the same workflow race for the same commit range. `sallyport` and `dotfiles` already use the CI form below; this brings the rest in line.

For CI and lint workflows, cancelling the older run is the point:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

For release and deploy workflows the opposite is true — interrupting one halfway can leave a partial release or a half-finished deployment — so those get `cancel-in-progress: false`.

Verified with `actionlint` and `zizmor --offline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
