### PR TITLE
ci: attest release provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -82,18 +84,19 @@ jobs:
         with:
           path: artifacts
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: artifacts/*/nooon-*
+
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          assets=(
-            artifacts/nooon-linux-x64/nooon-linux-x64
-            artifacts/nooon-linux-arm64/nooon-linux-arm64
-            artifacts/nooon-darwin-x64/nooon-darwin-x64
-            artifacts/nooon-darwin-arm64/nooon-darwin-arm64
-          )
-          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release upload "${GITHUB_REF_NAME}" "${assets[@]}" --clobber
-          else
-            gh release create "${GITHUB_REF_NAME}" "${assets[@]}" --verify-tag --notes ""
-          fi
+        run: >-
+          gh release create "${GITHUB_REF_NAME}"
+          artifacts/nooon-linux-x64/nooon-linux-x64
+          artifacts/nooon-linux-arm64/nooon-linux-arm64
+          artifacts/nooon-darwin-x64/nooon-darwin-x64
+          artifacts/nooon-darwin-arm64/nooon-darwin-arm64
+          --verify-tag
+          --notes ""


### PR DESCRIPTION
## Changes

- Attest build provenance for the four release binaries.
- Drop the `gh release upload --clobber` fallback and go back to a plain `gh release create`.

## Provenance

`actions/attest-build-provenance` records which workflow, at which commit, produced these binaries, and signs that statement. Anyone can check a download with `gh attestation verify nooon-darwin-arm64 --repo corrupt952/nooon`. The job needs `id-token: write` to request the signing token and `attestations: write` to store the result.

Attestation happens after `download-artifact` and before the release is created, so the artifacts are attested exactly as they are published.

## Removing the `--clobber` fallback

I added that fallback earlier today, on the reasoning that replacing `softprops/action-gh-release` with `gh release create` had removed the ability to recover from a release that failed partway. That reasoning was wrong.

`gh release create` does not leave a half-finished release behind. When there are assets, it creates the release as a draft, uploads everything, and only then publishes — and deletes the draft if any step fails. This is documented in `gh`'s own help text:

> Immutability is enforced only after a release is published. … are made to create the release as a draft, upload the assets, and then publish the release.

So the branch only ever runs when a *published* release already exists for the tag, which is not a recovery case — it is overwriting a release that has already shipped. Immutable releases are being enabled on this repository, which forbids exactly that, so the branch would become code that can only fail. Better to remove it than to leave a path that fails confusingly.

## Verification

`actionlint` and `zizmor --offline` are clean. This workflow only runs on tag pushes, so it is not exercised by pull request CI — the first real run will be the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
